### PR TITLE
Iframe showing up on hot reload Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint-staged": "10.5.4",
     "npm-run-all": "4.1.5",
     "prettier": "2.2.1",
+    "react-error-overlay": "6.0.9",
     "react-scripts": "4.0.3"
   },
   "scripts": {
@@ -34,6 +35,9 @@
     "lint:fix": "eslint --fix src/",
     "format": "prettier --write \"./src\"",
     "run-all": "npm-run-all --parallel test lint:fix"
+  },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
During development on hot reload there's an ```<frame />``` tag showing up and potentially blocking UI i.e filter buttons become unclickable since ```<iframe />``` has a higher ```z-index``` value. 

It's a common issue, the fix can be found [here](https://github.com/facebook/create-react-app/issues/11880)